### PR TITLE
Fix how sample size is defined 

### DIFF
--- a/src/cost_model_queries/examples/config.csv
+++ b/src/cost_model_queries/examples/config.csv
@@ -1,9 +1,9 @@
 ﻿cost_type,sheet,factor_names,cell_row,cell_col,range_lower,range_upper,is_cat
 production,Dashboard,setupCost,14,12,1000,1000000,FALSE
 production,Dashboard,Cost,16,12,1000,1000000,FALSE
-production,Dashboard,num_devices,5,5,1,100000000,TRUE
+production,Dashboard,num_devices,5,5,1000,1000000,TRUE
 production,Dashboard,species_no,10,5,19,23,TRUE
-production,Conversions,col_spawn_gam_bun,7,6,57600,70400,TRUE
+production,Conversions,col_spawn_gam_bun,7,6,22500,27500,TRUE
 production,Conversions,gam_bun_egg,8,7,10,14,TRUE
 production,Conversions,egg_embryo,9,8,0.7,0.9,FALSE
 production,Conversions,embryo_freeswim,10,9,0.7,0.9,FALSE
@@ -11,7 +11,7 @@ production,Conversions,freeswim_settle,11,10,0.7,0.9,FALSE
 production,Conversions,settle_just,12,11,0.7,0.9,FALSE
 production,Conversions,just_unit,14,11,6,9,TRUE
 production,Conversions,just_mature,14,15,0.7,0.9,FALSE
-production,Conversions,1YOEC_yield,19,18,0.6,0.8,FALSE
+production,Conversions,1YOEC_yield,19,18,0.7,0.8,FALSE
 production,Logistics,optimal_rear_dens,11,5,1,3,TRUE
 deployment,Dashboard,setupCost,11,11,1000,1000000,FALSE
 deployment,Dashboard,Cost,6,11,1000,1000000,FALSE
@@ -20,10 +20,10 @@ deployment,Dashboard,port,6,4,0,4,TRUE
 deployment,Dashboard,DAJ_a_r,9,4,9,10,TRUE
 deployment,Dashboard,DAJ_c_s,10,4,1,2,TRUE
 deployment,Dashboard,deck_space,13,4,39,40,FALSE
-deployment,Lookup Tables,cape_ferg_price,19,7,12500,13500,FALSE
-deployment,Lookup Tables,ship_endurance,19,15,13,15,TRUE
+deployment,Lookup Tables,cape_ferg_price,23,7,6000,8000,FALSE
+deployment,Lookup Tables,ship_endurance,23,15,13,15,TRUE
 deployment,Lookup Tables,distance_from_port,54,8,1,210,FALSE
-deployment,Conversions,1YOEC_yield,25,5,0.6,0.8,FALSE
+deployment,Conversions,1YOEC_yield,25,5,0.7,0.8,FALSE
 deployment,Logistics,secs_per_dev,84,6,0,1,TRUE
 deployment,Logistics,proportion,84,9,0.5,0.55,FALSE
 deployment,Logistics,bins_per_tender,83,9,4,6,TRUE

--- a/src/cost_model_queries/examples/sample_deployment_cost_model.py
+++ b/src/cost_model_queries/examples/sample_deployment_cost_model.py
@@ -11,11 +11,11 @@ from cost_model_queries.sampling.sampling_functions import (
 samples_save_fn = "deployment_cost_samples.csv"
 
 # Path to cost model
-file_name = "\\Cost Models\\3.5.3 CA Deployment Model.xlsx"
+file_name = "\\Cost Models\\3.5.5 CA Deployment Model.xlsx"
 wb_file_path = os.path.abspath(os.getcwd()) + file_name
 
 # Generate sample
-N = 2**10
+N = 2**5
 
 # Generate problem spec, factor names and list of categorical factors to create factor sample
 sp, factor_specs = problem_spec("deployment")

--- a/src/cost_model_queries/examples/sample_deployment_cost_model.py
+++ b/src/cost_model_queries/examples/sample_deployment_cost_model.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import os
 
 from cost_model_queries.sampling.sampling_functions import (
     problem_spec,
@@ -27,5 +28,5 @@ factors_df = pd.DataFrame(data=sp.samples, columns=factor_specs.factor_names)
 factors_df = convert_factor_types(factors_df, factor_specs.is_cat)
 
 # Sample cost using factors sampled
-factors_df = sample_deployment_cost(wb_file_path, factors_df, factor_specs, N)
+factors_df = sample_deployment_cost(wb_file_path, factors_df, factor_specs)
 factors_df.to_csv(samples_save_fn, index=False)  # Save to CSV

--- a/src/cost_model_queries/examples/sample_production_cost_model.py
+++ b/src/cost_model_queries/examples/sample_production_cost_model.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import os
 
 from cost_model_queries.sampling.sampling_functions import (
     problem_spec,
@@ -27,5 +28,5 @@ factors_df = pd.DataFrame(data=sp.samples, columns=factor_specs.factor_names)
 factors_df = convert_factor_types(factors_df, factor_specs.is_cat)
 
 # Sample cost using factors sampled
-factors_df = sample_production_cost(wb_file_path, factors_df, factor_specs, N)
+factors_df = sample_production_cost(wb_file_path, factors_df, factor_specs)
 factors_df.to_csv(samples_save_fn, index=False)  # Save to CSV

--- a/src/cost_model_queries/examples/sample_production_cost_model.py
+++ b/src/cost_model_queries/examples/sample_production_cost_model.py
@@ -11,11 +11,11 @@ from cost_model_queries.sampling.sampling_functions import (
 samples_save_fn = "production_cost_samples.csv"
 
 # Path to cost model
-file_name = "\\Cost Models\\3.5.2 CA Production Model.xlsx"
+file_name = "\\Cost Models\\3.7.0 CA Production Model.xlsx"
 wb_file_path = os.path.abspath(os.getcwd()) + file_name
 
 # Generate sample
-N = 2**3
+N = 2**5
 
 # Generate problem spec, factor names and list of categorical factors to create factor sample
 sp, factor_specs = problem_spec("production")

--- a/src/cost_model_queries/sampling/sampling_functions.py
+++ b/src/cost_model_queries/sampling/sampling_functions.py
@@ -166,7 +166,7 @@ def convert_factor_types(factors_df, is_cat):
     return factors_df
 
 
-def _sample_cost(wb_file_path, factors_df, factor_spec, N, calculate_cost, n_factors):
+def _sample_cost(wb_file_path, factors_df, factor_spec, calculate_cost):
     """
     Sample a cost model.
 
@@ -191,7 +191,7 @@ def _sample_cost(wb_file_path, factors_df, factor_spec, N, calculate_cost, n_fac
     xlApp = win32com.client.Dispatch("Excel.Application")  # Open workbook
     wb = xlApp.Workbooks.Open(wb_file_path)
 
-    total_cost = np.zeros((int(N * (2 * n_factors + 2)), 2))
+    total_cost = np.zeros((factors_df.shape[0], 2))
     for idx_n in range(len(total_cost)):
         total_cost[idx_n, :] = calculate_cost(wb, factor_spec, factors_df.iloc[[idx_n]])
 
@@ -202,7 +202,7 @@ def _sample_cost(wb_file_path, factors_df, factor_spec, N, calculate_cost, n_fac
     return factors_df
 
 
-def sample_deployment_cost(wb_file_path, factors_df, factor_spec, N, **kwargs):
+def sample_deployment_cost(wb_file_path, factors_df, factor_spec):
     """
     Sample the deployment cost model.
 

--- a/src/cost_model_queries/sampling/sampling_functions.py
+++ b/src/cost_model_queries/sampling/sampling_functions.py
@@ -178,8 +178,6 @@ def _sample_cost(wb_file_path, factors_df, factor_spec, calculate_cost):
             Dataframe of factors to input in the cost model
         factor_spec : dataframe
             factor specification, as loaded from the config.csv
-        N : int
-            Number of samples input to SALib sampling function
         calculate_cost: function
             Function to use to sample cost
 
@@ -214,19 +212,16 @@ def sample_deployment_cost(wb_file_path, factors_df, factor_spec):
             Dataframe of factors to input in the cost model
         factor_spec : dataframe
             factor specification, as loaded from the config.csv
-        N : int
-            Number of samples input to SALib sampling function
 
     Returns
     -------
         factors_df : dataframe
             Updated sampled factor dataframe with costs added
     """
-    n_factors = kwargs.get('n_factors', factors_df.shape[1])
-    return _sample_cost(wb_file_path, factors_df, factor_spec, N, calculate_deployment_cost, n_factors=n_factors)
+    return _sample_cost(wb_file_path, factors_df, factor_spec, calculate_deployment_cost)
 
 
-def sample_production_cost(wb_file_path, factors_df, factor_spec, N, **kwargs):
+def sample_production_cost(wb_file_path, factors_df, factor_spec):
     """
     Sample the production cost model.
 
@@ -238,16 +233,13 @@ def sample_production_cost(wb_file_path, factors_df, factor_spec, N, **kwargs):
             Dataframe of factors to input in the cost model
         factor_spec : dataframe
             Factor specification, as loaded from the config.csv
-        N : int
-            Number of samples input to SALib sampling function
 
     Returns
     -------
         factors_df : dataframe
             Updated sampled factor dataframe with costs added
     """
-    n_factors = kwargs.get('n_factors', factors_df.shape[1])
-    return _sample_cost(wb_file_path, factors_df, factor_spec, N, calculate_production_cost, n_factors=n_factors)
+    return _sample_cost(wb_file_path, factors_df, factor_spec, calculate_production_cost)
 
 
 def cost_sensitivity_analysis(samples_fn, cost_type, figures_path=".\\src\\figures\\"):

--- a/src/cost_model_queries/tests/test_sampling.py
+++ b/src/cost_model_queries/tests/test_sampling.py
@@ -5,7 +5,7 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from src.sampling.sampling_functions import (
+from cost_model_queries.sampling.sampling_functions import (
     problem_spec,
     convert_factor_types,
     sample_deployment_cost,
@@ -33,7 +33,7 @@ def test_sampling(cost_function, model_type, file_name):
     # Check any conversions to Int have worked
     assert all(check_types)
 
-    factors_df = cost_function(wb_file_path, factors_df, factor_specs, N)
+    factors_df = cost_function(wb_file_path, factors_df, factor_specs)
     check_sample = [math.isnan(factors_df[factor_specs.factor_names].iloc[[0]][k][0]) for k in factor_specs.factor_names]
 
     # Check sampling has worked (no Nans due to sampling empty cells)
@@ -49,4 +49,3 @@ test_sampling(sample_deployment_cost, "deployment", "\\tests\\test_deployment_co
 
 # Test production model sampling
 test_sampling(sample_production_cost, "production", "\\tests\\test_production_cost_model.xlsx")
-breakpoint()


### PR DESCRIPTION
Previously, to ensure compatibility with the SALib method of calculating sample size, sample size was calculated as n_samples*(2*n_factors +2). This however, can be restrictive if using other sampling methods. To allow more flexibility and fewer inputs to the sampling functions, the sample size when sampling the cost models is now defined simply as the size of the sample matrix, which could vary depending on the sampling method.